### PR TITLE
Fix: Supercronic skips a beat

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -85,20 +85,14 @@ func runJob(context *crontab.Context, command string, jobLogger *logrus.Entry) e
 	return nil
 }
 
-func StartJob(wg *sync.WaitGroup, context *crontab.Context, job *crontab.Job, exitChan chan interface{}) {
+func StartJob(wg *sync.WaitGroup, context *crontab.Context, job *crontab.Job, exitChan chan interface{}, cronLogger *logrus.Entry) {
 	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
 
-		cronLogger := logrus.WithFields(logrus.Fields{
-			"job.schedule": job.Schedule,
-			"job.command":  job.Command,
-			"job.position": job.Position,
-		})
-
 		var cronIteration uint64 = 0
-		nextRun := job.Expression.Next(time.Now())
+		nextRun := time.Now()
 
 		// NOTE: this (intentionally) does not run multiple instances of the
 		// job concurrently

--- a/main.go
+++ b/main.go
@@ -61,9 +61,16 @@ func main() {
 	)
 
 	for _, job := range tab.Jobs {
-		c := make(chan interface{}, 1)
-		exitChans = append(exitChans, c)
-		cron.StartJob(&wg, tab.Context, job, c)
+		exitChan := make(chan interface{}, 1)
+		exitChans = append(exitChans, exitChan)
+
+		cronLogger := logrus.WithFields(logrus.Fields{
+			"job.schedule": job.Schedule,
+			"job.command":  job.Command,
+			"job.position": job.Position,
+		})
+
+		cron.StartJob(&wg, tab.Context, job, exitChan, cronLogger)
 	}
 
 	termChan := make(chan os.Signal, 1)


### PR DESCRIPTION
We're launching everything one iteration later than scheduled. That's
not great!

I'd like to rethink the test approach a little bit here. Testing through
the logger is not ideal (we should probably just pump all the logs
through channels back to the main goroutine).