### PR TITLE
add multi-stage dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*.md
+integration
+.travis.yml
+**/*_test.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM billyteves/alpine-golang-glide:1.2.0 as builder
+FROM alpine:3.6 as builder
 
+RUN apk add --no-cache go glide git build-base
+
+ENV GOPATH /go
 WORKDIR /go/src/github.com/aptible/supercronic/
-# Download dependencies in a separate layer to optimize
-# the use of the layers cache even when the project code changes
 COPY glide.yaml .
+COPY glide.lock .
 RUN glide install
-
 COPY . .
-RUN make build
+RUN go build -i
 
-# Build final image straight from alpine
-FROM alpine:latest
-WORKDIR /root/
-COPY --from=builder /go/src/github.com/aptible/supercronic/supercronic .
-ENTRYPOINT ["./supercronic"]
+FROM alpine
+COPY --from=builder /go/src/github.com/aptible/supercronic/supercronic /usr/local/bin/
+ENTRYPOINT ["supercronic"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM billyteves/alpine-golang-glide:1.2.0 as builder
+
+WORKDIR /go/src/github.com/aptible/supercronic/
+COPY glide.yaml .
+RUN glide install
+COPY . .
+RUN make build
+
+FROM alpine:latest
+
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/aptible/supercronic/supercronic .
+ENTRYPOINT ["./supercronic"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM billyteves/alpine-golang-glide:1.2.0 as builder
 
 WORKDIR /go/src/github.com/aptible/supercronic/
+# Download dependencies in a separate layer to optimize
+# the use of the layers cache even when the project code changes
 COPY glide.yaml .
 RUN glide install
+
 COPY . .
 RUN make build
 
+# Build final image straight from alpine
 FROM alpine:latest
-
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/aptible/supercronic/supercronic .
 ENTRYPOINT ["./supercronic"]

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,5 @@ import:
   version: ~1.0.0
 - package: github.com/stretchr/testify
   version: ~1.1.4
+- package: golang.org/x/crypto/ssh/terminal
+- package: golang.org/x/sys/unix


### PR DESCRIPTION
Hi,

This looks like a cool project but for an utility tool supposed to run in a container, it seemed ironic that there was no Dockerfile 😉 

The docker file in this PR uses the [docker multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) to generate the smallest image possible that allows anyone to try the tool.

```
$ docker images
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
supercronic                      latest              160c8c800af0        9 minutes ago       6.93MB <-- Final image size
<none>                           <none>              9d1ecaaeb93b        9 minutes ago       303MB <-- Build image size
```

 from an alpine-based container as it with `docker run supercronic:latest <path/to/crontab>` or to use it as a base image on which the crontab files can be added.