### PR TITLE
Add overlapping flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ INFO[2017-07-11T12:24:32+02:00] job succeeded                                 it
 WARN[2017-07-11T12:24:32+02:00] job took too long to run: it should have started 1.014474099s ago  job.command="sleep 2" job.position=0 job.schedule="* * * * * * *"
 ```
 
+You can optionally disable this behavior and allow overlapping instances of
+your jobs by passing the `-overlapping` flag to Supercronic. Supercronic will
+still warn about jobs falling behind, but will run duplicate instances of them.
+
 
 ## Reload crontab
 

--- a/crontab/crontab.go
+++ b/crontab/crontab.go
@@ -3,11 +3,12 @@ package crontab
 import (
 	"bufio"
 	"fmt"
-	"github.com/gorhill/cronexpr"
-	"github.com/sirupsen/logrus"
 	"io"
 	"regexp"
 	"strings"
+
+	"github.com/gorhill/cronexpr"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/crontab/crontab_test.go
+++ b/crontab/crontab_test.go
@@ -3,8 +3,9 @@ package crontab
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var parseCrontabTestCases = []struct {

--- a/integration/test.bats
+++ b/integration/test.bats
@@ -57,6 +57,11 @@ wait_for() {
   [[ "$n" -eq 2 ]]
 }
 
+@test "it runs overlapping jobs" {
+  n="$(SUPERCRONIC_ARGS="-overlapping" run_supercronic "${BATS_TEST_DIRNAME}/timeout.crontab" 5s | grep -iE "starting" | wc -l)"
+  [[ "$n" -ge 4 ]]
+}
+
 @test "it supports debug logging " {
   SUPERCRONIC_ARGS="-debug" run_supercronic "${BATS_TEST_DIRNAME}/hello.crontab" | grep -iE "debug"
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	splitLogs := flag.Bool("split-logs", false, "split log output into stdout/stderr")
 	sentry := flag.String("sentry-dsn", "", "enable Sentry error logging, using provided DSN")
 	sentryAlias := flag.String("sentryDsn", "", "alias for sentry-dsn")
+	overlapping := flag.Bool("overlapping", false, "enable tasks overlapping")
 	flag.Parse()
 
 	var sentryDsn string
@@ -111,7 +112,7 @@ func main() {
 				"job.position": job.Position,
 			})
 
-			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger)
+			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger, *overlapping)
 		}
 
 		termChan := make(chan os.Signal, 1)


### PR DESCRIPTION
This PR adds `-overlapping` flag (default false) which allows running overlapped jobs.

Other changes:

- Modify `.travis.yml` to allow forks testing
- Switch from `glide` to `dep` as it will become official vendoring tool
- Upgrade from go 1.8 to 1.9