### PR TITLE
Allow CI working in forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ dist: trusty
 
 language: go
 
-go: "1.8"
+go: "1.9"
+
+before_install:
+  - mkdir -p $HOME/gopath/src/github.com/aptible/supercronic
+  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/aptible/supercronic/
+  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/aptible/supercronic
+  - cd $TRAVIS_BUILD_DIR
 
 addons:
   apt:


### PR DESCRIPTION
Travis checks out the code in the `github.com/user/supercronic` folder but in the code, there are imports of `github.com/aptible/supercronic/cron` and `github.com/aptible/supercronic/crontab` packages. During vendoring, they are downloaded from the original repo and build fails.

This PR adds `before_install` step which copies the source code into `github.com/aptible/supercronic` directory.