### PR TITLE
startReaderDrain: close before reporting done

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -23,10 +23,10 @@ func startReaderDrain(wg *sync.WaitGroup, readerLogger *logrus.Entry, reader io.
 
 	go func() {
 		defer func() {
-			wg.Done()
 			if err := reader.Close(); err != nil {
 				readerLogger.Errorf("failed to close pipe: %v", err)
 			}
+			wg.Done()
 		}()
 
 		bufReader := bufio.NewReaderSize(reader, READ_BUFFER_SIZE)


### PR DESCRIPTION
Calling `Wait()` on the process will cause the runtime to close our
reader pipes. Since we're deliberately closing the pipes ourselves, we
need to do so *before* calling `Wait()`.

`Wait()` is called once the wait group completes, so we can do this by
simply closing the pipe before reporting we're done.

---

FYI @fancyremarker 