### PR TITLE
Add split-stream flag to split stdout/stderr log.

### DIFF
--- a/log/writer/splitstream.go
+++ b/log/writer/splitstream.go
@@ -1,0 +1,30 @@
+package writer
+
+import (
+	"bytes"
+	"os"
+	"github.com/sirupsen/logrus"
+	"encoding/json"
+)
+
+type TextSplitStreamWriter struct {}
+func (ss *TextSplitStreamWriter) Write(entry []byte) (n int, err error) {
+	if bytes.Contains(entry, []byte("level=debug")) || bytes.Contains(entry, []byte("level=info")) {
+		return os.Stdout.Write(entry)
+	}
+	return os.Stderr.Write(entry)
+}
+
+type JsonSplitStreamWriter struct {}
+func (ss *JsonSplitStreamWriter) Write(entry []byte) (n int, err error) {
+	var log map[string]interface{}
+	json.Unmarshal(entry, &log)
+	if level, ok := log[logrus.FieldKeyLevel]; ok {
+		if level == "debug" || level == "info" {
+			return os.Stdout.Write(entry)
+		}
+	}
+	return os.Stderr.Write(entry)
+}
+
+

--- a/log/writer/splitstream_test.go
+++ b/log/writer/splitstream_test.go
@@ -1,0 +1,126 @@
+package writer
+
+import (
+	"testing"
+	"os"
+	"bytes"
+	"io"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+func TestTextSplitStreamWriter_Write(t *testing.T) {
+
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetFormatter(&logrus.TextFormatter{})
+	logrus.SetOutput(&TextSplitStreamWriter{})
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	er, ew, _ := os.Pipe()
+	sr, sw, _ := os.Pipe()
+	os.Stdout = sw
+	os.Stderr = ew
+
+	outChan := make(chan string, 2)
+	go func() {
+		var stdoutBuff bytes.Buffer
+		io.Copy(&stdoutBuff, sr)
+		outChan <- stdoutBuff.String()
+		outChan <- stdoutBuff.String()
+	}()
+
+	errChan := make(chan string, 2)
+	go func() {
+		var stderrOut bytes.Buffer
+		io.Copy(&stderrOut, er)
+		errChan <- stderrOut.String()
+		errChan <- stderrOut.String()
+	}()
+
+	logrus.Debug("out1")
+	logrus.Info("out2")
+	logrus.Warn("err1")
+	logrus.Error("err2")
+
+	sw.Close()
+	ew.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	stdoutMsg := <-outChan
+	stderrMsg := <-errChan
+	if !strings.Contains(stdoutMsg, "msg=out1") {
+		t.Fatalf("failed to split info level log into stdout")
+	}
+	if !strings.Contains(stderrMsg, "msg=err1") {
+		t.Fatalf("failed to split error level log into stderr")
+	}
+
+	stdoutMsg = <-outChan
+	stderrMsg = <-errChan
+	if !strings.Contains(stdoutMsg, "msg=out2") {
+		t.Fatalf("failed to split info level log into stdout")
+	}
+	if !strings.Contains(stderrMsg, "msg=err2") {
+		t.Fatalf("failed to split error level log into stderr")
+	}
+}
+
+func TestJsonSplitStreamWriter_Write(t *testing.T) {
+
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(&JsonSplitStreamWriter{})
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	er, ew, _ := os.Pipe()
+	sr, sw, _ := os.Pipe()
+	os.Stdout = sw
+	os.Stderr = ew
+
+	outChan := make(chan string, 2)
+	go func() {
+		var stdoutBuff bytes.Buffer
+		io.Copy(&stdoutBuff, sr)
+		outChan <- stdoutBuff.String()
+		outChan <- stdoutBuff.String()
+	}()
+
+	errChan := make(chan string, 2)
+	go func() {
+		var stderrOut bytes.Buffer
+		io.Copy(&stderrOut, er)
+		errChan <- stderrOut.String()
+		errChan <- stderrOut.String()
+	}()
+
+	logrus.Debug("out1")
+	logrus.Info("out2")
+	logrus.Warn("err1")
+	logrus.Error("err2")
+
+	sw.Close()
+	ew.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	stdoutMsg := <-outChan
+	stderrMsg := <-errChan
+	if !strings.Contains(stdoutMsg, "\"msg\":\"out1\"") {
+		t.Fatalf("failed to split info level log into stdout")
+	}
+	if !strings.Contains(stderrMsg, "\"msg\":\"err1\"") {
+		t.Fatalf("failed to split error level log into stderr")
+	}
+
+	stdoutMsg = <-outChan
+	stderrMsg = <-errChan
+	if !strings.Contains(stdoutMsg, "\"msg\":\"out2\"") {
+		t.Fatalf("failed to split info level log into stdout")
+	}
+	if !strings.Contains(stderrMsg, "\"msg\":\"err2\"") {
+		t.Fatalf("failed to split error level log into stderr")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/aptible/supercronic/cron"
 	"github.com/aptible/supercronic/crontab"
+	"github.com/aptible/supercronic/log/writer"
 	"github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
@@ -21,6 +22,7 @@ var Usage = func() {
 func main() {
 	debug := flag.Bool("debug", false, "enable debug logging")
 	json := flag.Bool("json", false, "enable JSON logging")
+	splitStream := flag.Bool("split-stream", false, "split log stream into stdout and stderr")
 	flag.Parse()
 
 	if *debug {
@@ -31,6 +33,14 @@ func main() {
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 	} else {
 		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	}
+
+	if *splitStream {
+		if *json {
+			logrus.SetOutput(&writer.JsonSplitStreamWriter{})
+		} else {
+			logrus.SetOutput(&writer.TextSplitStreamWriter{})
+		}
 	}
 
 	if flag.NArg() != 1 {


### PR DESCRIPTION
Hi, 

As I asked in [here](https://github.com/aptible/supercronic/issues/40), there is no plan to add an option that split log stream into stdout/stderr.
So, I added an option `split-stream` to split stdout/stderr logs.
Log goes to stdout if log level is either `debug` or `info`, otherwise goes to stderr.

Please review it, thanks.