### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Then, fetch Supercronic, install its dependencies, then install it:
 ```
 go get -d github.com/aptible/supercronic
 cd "${GOPATH}/src/github.com/aptible/supercronic"
-dep ensure
+dep ensure -vendor-only
 go install
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ dep][dep] first.
 Then, fetch Supercronic, install its dependencies, then install it:
 
 ```
-go get github.com/aptible/supercronic
+go get -d github.com/aptible/supercronic
 cd "${GOPATH}/src/github.com/aptible/supercronic"
 dep ensure
 go install


### PR DESCRIPTION
On build process as the dependencies were not resolved yet, `go get -d` is more suitable on the build process.