### PR TITLE
Disable cgo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ jobs:
       script:
         - mkdir -p dist
         - export GOOS="linux"
-        - for arch in amd64 386 arm arm64; do GOARCH="$arch" go build && mv supercronic "dist/supercronic-${GOOS}-${arch}"; done
+        - export CGO_ENABLED=0
+        - for arch in amd64 386 arm arm64; do GOARCH="$arch" go build && file supercronic | grep 'statically linked' && mv supercronic "dist/supercronic-${GOOS}-${arch}"; done
         - pushd dist
         - ls -lah *
         - file *


### PR DESCRIPTION
When we introduced Sentry error-reporting, we pulled in the Go network
stack, and that resulted in building binaries that link to libc.

This updates our CI scripts to:

- Disable CGO
- Check the binaries are static

Closes: #47