### PR TITLE
Add Prometheus instrumentation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:0d3deb8a6da8ffba5635d6fb1d2144662200def6c9d82a35a6d05d6c2d4a48f9"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = ""
+  revision = "4b2b341e8d7715fae06375aa633dbb6e91b3fb46"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:8722889ad027febfced94665914d1e7be8f1b703d31f2ef9461c59e4d40fe974"
   name = "github.com/certifi/gocertifi"
   packages = ["."]
@@ -34,6 +42,14 @@
   revision = "a9457d81ec91fa6d538567f14c6138e9ce5a37fb"
 
 [[projects]]
+  digest = "1:529d738b7976c3848cae5cf3a8036440166835e389c1f617af701eeb12a0518d"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = ""
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
+
+[[projects]]
   branch = "strict"
   digest = "1:8928810213f9690c5e1cbd19b004a8c97ecc457f0a8c1da362bd96bdc3a5ab8c"
   name = "github.com/gorhill/cronexpr"
@@ -41,6 +57,14 @@
   pruneopts = ""
   revision = "b648cc9a908c22490de781dbe600459edd0ac533"
   source = "github.com/krallin/cronexpr"
+
+[[projects]]
+  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = ""
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
@@ -57,6 +81,49 @@
   pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:dafd1471a472c8a3905036a89f5711b2e9f8e639489d649d9f497e0222971b39"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = ""
+  revision = "b46e6ec51bb1e8aca796f58a8462a8ff125c3ddd"
+
+[[projects]]
+  branch = "master"
+  digest = "1:cd67319ee7536399990c4b00fae07c3413035a53193c644549a676091507cadc"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = ""
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+
+[[projects]]
+  digest = "1:acd87a73c6a6f2d61ad04822d68b233a5c12f5b72aef3db0985f90680e9ae8f0"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
+  revision = "1ba88736f028e37bc17328369e94a537ae9e0234"
+  version = "v0.4.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5ee701aab36918e3c5db39ee3b42b85a7c8ae0ab60ec137457ea951e9b5e34a6"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+  ]
+  pruneopts = ""
+  revision = "be78308d8a4ffcb4610e8d21f0e15524ea0d646f"
 
 [[projects]]
   digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
@@ -99,6 +166,8 @@
   input-imports = [
     "github.com/evalphobia/logrus_sentry",
     "github.com/gorhill/cronexpr",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,3 +33,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "~1.1.4"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/prometheus/client_golang"

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -195,7 +195,7 @@ func TestStartJobExitsOnRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	StartJob(&wg, &basicContext, &job, ctx, logger, false)
+	StartJob(&wg, &basicContext, &job, ctx, logger, false, nil)
 
 	wg.Wait()
 }
@@ -215,7 +215,7 @@ func TestStartJobRunsJob(t *testing.T) {
 
 	logger, channel := newTestLogger()
 
-	StartJob(&wg, &basicContext, &job, ctx, logger, false)
+	StartJob(&wg, &basicContext, &job, ctx, logger, false, nil)
 
 	select {
 	case entry := <-channel:

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aptible/supercronic/crontab"
+	"github.com/aptible/supercronic/prometheus_metrics"
 )
 
 var (
 	TEST_CHANNEL_BUFFER_SIZE = 100
+	PROM_METRICS             = prometheus_metrics.NewPrometheusMetrics()
 )
 
 type testHook struct {
@@ -195,7 +197,7 @@ func TestStartJobExitsOnRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	StartJob(&wg, &basicContext, &job, ctx, logger, false, nil)
+	StartJob(&wg, &basicContext, &job, ctx, logger, false, &PROM_METRICS)
 
 	wg.Wait()
 }
@@ -215,7 +217,7 @@ func TestStartJobRunsJob(t *testing.T) {
 
 	logger, channel := newTestLogger()
 
-	StartJob(&wg, &basicContext, &job, ctx, logger, false, nil)
+	StartJob(&wg, &basicContext, &job, ctx, logger, false, &PROM_METRICS)
 
 	select {
 	case entry := <-channel:

--- a/main.go
+++ b/main.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/aptible/supercronic/cron"
-	"github.com/aptible/supercronic/crontab"
-	"github.com/aptible/supercronic/log/hook"
-	"github.com/evalphobia/logrus_sentry"
-	"github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/aptible/supercronic/cron"
+	"github.com/aptible/supercronic/crontab"
+	"github.com/aptible/supercronic/log/hook"
+	"github.com/aptible/supercronic/prometheus_metrics"
+	"github.com/evalphobia/logrus_sentry"
+	"github.com/sirupsen/logrus"
 )
 
 var Usage = func() {
@@ -25,6 +27,7 @@ func main() {
 	debug := flag.Bool("debug", false, "enable debug logging")
 	json := flag.Bool("json", false, "enable JSON logging")
 	test := flag.Bool("test", false, "test crontab (does not run jobs)")
+	prometheusListen := flag.String("prometheus-listen-address", "", "give a valid ip:port address to expose Prometheus metrics at /metrics")
 	splitLogs := flag.Bool("split-logs", false, "split log output into stdout/stderr")
 	sentry := flag.String("sentry-dsn", "", "enable Sentry error logging, using provided DSN")
 	sentryAlias := flag.String("sentryDsn", "", "alias for sentry-dsn")
@@ -50,7 +53,6 @@ func main() {
 	} else {
 		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
 	}
-
 	if *splitLogs {
 		hook.RegisterSplitLogger(
 			logrus.StandardLogger(),
@@ -87,7 +89,29 @@ func main() {
 		}
 	}
 
+	var prommetrics *prometheus_metrics.PrometheusMetrics
+
+	if *prometheusListen != "" {
+		prommetrics = prometheus_metrics.New(*prometheusListen)
+
+		go func() {
+			if err := prommetrics.InitHTTPServer(); err != nil {
+				logrus.Fatalf("prometheus http startup: %s", err.Error())
+			}
+		}()
+
+		defer func() {
+			if err := prommetrics.ShutdownHTTPServer(context.Background()); err != nil {
+				logrus.Fatalf("prometheus http shutdown: %s", err.Error())
+			}
+		}()
+	}
+
 	for true {
+		if prommetrics != nil {
+			prommetrics.Reset()
+		}
+
 		logrus.Infof("read crontab: %s", crontabFileName)
 		tab, err := readCrontabAtPath(crontabFileName)
 
@@ -112,7 +136,7 @@ func main() {
 				"job.position": job.Position,
 			})
 
-			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger, *overlapping)
+			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger, *overlapping, prommetrics)
 		}
 
 		termChan := make(chan os.Signal, 1)

--- a/prometheus_metrics/prommetrics.go
+++ b/prometheus_metrics/prommetrics.go
@@ -123,9 +123,8 @@ func InitHTTPServer(listenAddr string, shutdownContext context.Context) (func() 
 		return shutdownClosure, err
 	}
 
-	server := &http.Server{}
 	go func() {
-		if err := server.Serve(listener); err != nil {
+		if err := promSrv.Serve(listener); err != nil {
 			logrus.Fatalf("prometheus http serve failed: %s", err.Error())
 		}
 	}()

--- a/prometheus_metrics/prommetrics.go
+++ b/prometheus_metrics/prommetrics.go
@@ -1,0 +1,115 @@
+package prometheus_metrics
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type PrometheusMetrics struct {
+	CronsCurrentlyRunningGauge   *prometheus.GaugeVec
+	CronsExecCounter             *prometheus.CounterVec
+	CronsSuccessCounter          *prometheus.CounterVec
+	CronsFailCounter             *prometheus.CounterVec
+	CronsDeadlineExceededCounter *prometheus.CounterVec
+	CronsExecutionTimeHistogram  *prometheus.HistogramVec
+	listenAddr                   string
+	srv                          *http.Server
+}
+
+func New(promListenAddr string) *PrometheusMetrics {
+	pm := PrometheusMetrics{}
+
+	pm.listenAddr = promListenAddr
+
+	pm.CronsCurrentlyRunningGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "supercronic_currently_running",
+			Help: "count of currently running cron executions",
+		},
+		[]string{"command", "position", "schedule"},
+	)
+	prometheus.MustRegister(pm.CronsCurrentlyRunningGauge)
+
+	pm.CronsExecCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "supercronic_executions",
+			Help: "count of cron executions",
+		},
+		[]string{"command", "position", "schedule"},
+	)
+	prometheus.MustRegister(pm.CronsExecCounter)
+
+	pm.CronsSuccessCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "supercronic_successful_executions",
+			Help: "count of successul cron executions",
+		},
+		[]string{"command", "position", "schedule"},
+	)
+	prometheus.MustRegister(pm.CronsSuccessCounter)
+
+	pm.CronsFailCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "supercronic_failed_executions",
+			Help: "count of failed cron executions",
+		},
+		[]string{"command", "position", "schedule"},
+	)
+	prometheus.MustRegister(pm.CronsFailCounter)
+
+	pm.CronsDeadlineExceededCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "supercronic_deadline_exceeded",
+			Help: "count of exceeded deadline cron executions",
+		},
+		[]string{"command", "position", "schedule"},
+	)
+	prometheus.MustRegister(pm.CronsDeadlineExceededCounter)
+
+	pm.CronsExecutionTimeHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "supercronic_cron_execution_time_seconds",
+			Help:    "execution times of the cron runs in buckets",
+			Buckets: []float64{10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0, 3600.0}, // arbitrary buckets - 10s, 30s, 60s, 120s, 300s, 600s, 1800s, 3600s)
+		},
+		[]string{"command", "position", "schedule"},
+	)
+	prometheus.MustRegister(pm.CronsExecutionTimeHistogram)
+
+	return &pm
+}
+
+func (p *PrometheusMetrics) Reset() {
+	p.CronsCurrentlyRunningGauge.Reset()
+	p.CronsExecCounter.Reset()
+	p.CronsSuccessCounter.Reset()
+	p.CronsFailCounter.Reset()
+	p.CronsDeadlineExceededCounter.Reset()
+	p.CronsExecutionTimeHistogram.Reset()
+}
+
+func (p *PrometheusMetrics) InitHTTPServer() error {
+	promSrv := &http.Server{Addr: p.listenAddr}
+
+	http.Handle("/metrics", promhttp.Handler())
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+             <head><title>Supercronic</title></head>
+             <body>
+             <h1>Supercronic</h1>
+             <p><a href='/metrics'>Metrics</a></p>
+             </body>
+             </html>`))
+	})
+
+	p.srv = promSrv
+	return promSrv.ListenAndServe()
+}
+
+func (p *PrometheusMetrics) ShutdownHTTPServer(c context.Context) error {
+	return p.srv.Shutdown(c)
+}

--- a/prometheus_metrics/prommetrics.go
+++ b/prometheus_metrics/prommetrics.go
@@ -2,84 +2,92 @@ package prometheus_metrics
 
 import (
 	"context"
+	"net"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 )
 
-type PrometheusMetrics struct {
-	CronsCurrentlyRunningGauge   *prometheus.GaugeVec
-	CronsExecCounter             *prometheus.CounterVec
-	CronsSuccessCounter          *prometheus.CounterVec
-	CronsFailCounter             *prometheus.CounterVec
-	CronsDeadlineExceededCounter *prometheus.CounterVec
-	CronsExecutionTimeHistogram  *prometheus.HistogramVec
-	listenAddr                   string
-	srv                          *http.Server
+const (
+	namespace = "supercronic"
+)
+
+func genMetricName(name string) string {
+	return prometheus.BuildFQName(namespace, "", name)
 }
 
-func New(promListenAddr string) *PrometheusMetrics {
+type PrometheusMetrics struct {
+	CronsCurrentlyRunningGauge   prometheus.GaugeVec
+	CronsExecCounter             prometheus.CounterVec
+	CronsSuccessCounter          prometheus.CounterVec
+	CronsFailCounter             prometheus.CounterVec
+	CronsDeadlineExceededCounter prometheus.CounterVec
+	CronsExecutionTimeHistogram  prometheus.HistogramVec
+}
+
+func NewPrometheusMetrics() PrometheusMetrics {
+	cronLabels := []string{"command", "position", "schedule"}
+
 	pm := PrometheusMetrics{}
 
-	pm.listenAddr = promListenAddr
-
-	pm.CronsCurrentlyRunningGauge = prometheus.NewGaugeVec(
+	pm.CronsCurrentlyRunningGauge = *prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "supercronic_currently_running",
+			Name: genMetricName("currently_running"),
 			Help: "count of currently running cron executions",
 		},
-		[]string{"command", "position", "schedule"},
+		cronLabels,
 	)
 	prometheus.MustRegister(pm.CronsCurrentlyRunningGauge)
 
-	pm.CronsExecCounter = prometheus.NewCounterVec(
+	pm.CronsExecCounter = *prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "supercronic_executions",
+			Name: genMetricName("executions"),
 			Help: "count of cron executions",
 		},
-		[]string{"command", "position", "schedule"},
+		cronLabels,
 	)
 	prometheus.MustRegister(pm.CronsExecCounter)
 
-	pm.CronsSuccessCounter = prometheus.NewCounterVec(
+	pm.CronsSuccessCounter = *prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "supercronic_successful_executions",
+			Name: genMetricName("successful_executions"),
 			Help: "count of successul cron executions",
 		},
-		[]string{"command", "position", "schedule"},
+		cronLabels,
 	)
 	prometheus.MustRegister(pm.CronsSuccessCounter)
 
-	pm.CronsFailCounter = prometheus.NewCounterVec(
+	pm.CronsFailCounter = *prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "supercronic_failed_executions",
+			Name: genMetricName("failed_executions"),
 			Help: "count of failed cron executions",
 		},
-		[]string{"command", "position", "schedule"},
+		cronLabels,
 	)
 	prometheus.MustRegister(pm.CronsFailCounter)
 
-	pm.CronsDeadlineExceededCounter = prometheus.NewCounterVec(
+	pm.CronsDeadlineExceededCounter = *prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "supercronic_deadline_exceeded",
+			Name: genMetricName("deadline_exceeded"),
 			Help: "count of exceeded deadline cron executions",
 		},
-		[]string{"command", "position", "schedule"},
+		cronLabels,
 	)
 	prometheus.MustRegister(pm.CronsDeadlineExceededCounter)
 
-	pm.CronsExecutionTimeHistogram = prometheus.NewHistogramVec(
+	pm.CronsExecutionTimeHistogram = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "supercronic_cron_execution_time_seconds",
-			Help:    "execution times of the cron runs in buckets",
-			Buckets: []float64{10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0, 3600.0}, // arbitrary buckets - 10s, 30s, 60s, 120s, 300s, 600s, 1800s, 3600s)
+			Name:    genMetricName("cron_execution_time_seconds"),
+			Help:    "duration of the cron executions",
+			Buckets: []float64{10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0, 3600.0},
 		},
-		[]string{"command", "position", "schedule"},
+		cronLabels,
 	)
 	prometheus.MustRegister(pm.CronsExecutionTimeHistogram)
 
-	return &pm
+	return pm
 }
 
 func (p *PrometheusMetrics) Reset() {
@@ -91,8 +99,8 @@ func (p *PrometheusMetrics) Reset() {
 	p.CronsExecutionTimeHistogram.Reset()
 }
 
-func (p *PrometheusMetrics) InitHTTPServer() error {
-	promSrv := &http.Server{Addr: p.listenAddr}
+func InitHTTPServer(listenAddr string, shutdownContext context.Context) (func() error, error) {
+	promSrv := &http.Server{}
 
 	http.Handle("/metrics", promhttp.Handler())
 
@@ -106,10 +114,21 @@ func (p *PrometheusMetrics) InitHTTPServer() error {
              </html>`))
 	})
 
-	p.srv = promSrv
-	return promSrv.ListenAndServe()
-}
+	shutdownClosure := func() error {
+		return promSrv.Shutdown(shutdownContext)
+	}
 
-func (p *PrometheusMetrics) ShutdownHTTPServer(c context.Context) error {
-	return p.srv.Shutdown(c)
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return shutdownClosure, err
+	}
+
+	server := &http.Server{}
+	go func() {
+		if err := server.Serve(listener); err != nil {
+			logrus.Fatalf("prometheus http serve failed: %s", err.Error())
+		}
+	}()
+
+	return shutdownClosure, nil
 }


### PR DESCRIPTION
Fixes #50 

Feedback taken into account:

- [x]  We should expose a gauge representing how many instances of a given job are running at a given time. We can increment this at the start of the the runThisJob closure defined in StartJob then defer decrementing it.
- [x] We should add counters for executions, failures and successes (as opposed to the "last execution" gauge you have right now — more on this below). We can increment the relevant counters in the runThisJob closure defined in StartJob.
- [x] We should add a counter for jobs instances that exceed their deadline? We can increment this in monitorJob when the deadline is hit.
- [x] Measuring timings is a little tricky, since Prometheus wants us to aggregate those metrics to an extent... However, it's also very useful! I suppose we could use a histogram here with some arbitrary but reasonable buckets (e.g. 10 seconds, 30 seconds, 1 minute, 2 minutes, 5 minutes, 10 minutes, 30 minutes, 1 hour?)
- [x] We should make sure to shutdown the http sever when Supercronic exits.
- [x] Can we reset metrics when Supercronic's configuration is reloaded? We probably should, or the results won't make sense.
