### PR TITLE
Get Sentry DSN from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ Report errors to Sentry by passing a Sentry DSN:
 $ ./supercronic -sentry-dsn DSN
 ```
 
+You can also specify the DSN via the `SENTRY_DSN` environment variable.
+When a DSN is specified via both the environment variable and the command line parameter
+the parameter's DSN has priority.
+
 
 ## Questions and Support ###
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ func main() {
 
 	var sentryDsn string
 
+	sentryDsn = os.Getenv("SENTRY_DSN")
+
 	if *sentryAlias != "" {
 		sentryDsn = *sentryAlias
 	}


### PR DESCRIPTION
[When using the Sentry SDK in Go, it usually also reads the DSN from the SENTRY_DSN environment variable](https://docs.sentry.io/platforms/go/#configure)

This way Sentry can be configured from outside the container and one does not need an entrypoint to get the DSN from said environment variable.