### PR TITLE
Add `-passthrough-logs` and `-quiet`

### DIFF
--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -149,7 +149,7 @@ func TestRunJob(t *testing.T) {
 		label := fmt.Sprintf("RunJob(%q)", tt.command)
 		logger, channel := newTestLogger()
 
-		err := runJob(tt.context, tt.command, logger)
+		err := runJob(tt.context, tt.command, logger, false)
 		if tt.success {
 			assert.Nil(t, err, label)
 		} else {
@@ -197,7 +197,7 @@ func TestStartJobExitsOnRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	StartJob(&wg, &basicContext, &job, ctx, logger, false, &PROM_METRICS)
+	StartJob(&wg, &basicContext, &job, ctx, logger, false, false, &PROM_METRICS)
 
 	wg.Wait()
 }
@@ -217,7 +217,7 @@ func TestStartJobRunsJob(t *testing.T) {
 
 	logger, channel := newTestLogger()
 
-	StartJob(&wg, &basicContext, &job, ctx, logger, false, &PROM_METRICS)
+	StartJob(&wg, &basicContext, &job, ctx, logger, false, false, &PROM_METRICS)
 
 	select {
 	case entry := <-channel:

--- a/integration/test.bats
+++ b/integration/test.bats
@@ -70,6 +70,10 @@ wait_for() {
   SUPERCRONIC_ARGS="-json" run_supercronic "${BATS_TEST_DIRNAME}/noop.crontab" | grep -iE "^{"
 }
 
+@test "it supports passing command logging through" {
+  SUPERCRONIC_ARGS="-passthrough-logs" run_supercronic "${BATS_TEST_DIRNAME}/hello.crontab" | grep -iE "^hello from crontab$"
+}
+
 @test "it waits for jobs to exit before terminating" {
   ready="will start"
   canary="all done"

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var Usage = func() {
 
 func main() {
 	debug := flag.Bool("debug", false, "enable debug logging")
+	quiet := flag.Bool("quiet", false, "do not log informational messages (takes precedence over debug)")
 	json := flag.Bool("json", false, "enable JSON logging")
 	test := flag.Bool("test", false, "test crontab (does not run jobs)")
 	prometheusListen := flag.String("prometheus-listen-address", "", "give a valid ip:port address to expose Prometheus metrics at /metrics")
@@ -47,6 +48,10 @@ func main() {
 
 	if *debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	if *quiet {
+		logrus.SetLevel(logrus.WarnLevel)
 	}
 
 	if *json {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	test := flag.Bool("test", false, "test crontab (does not run jobs)")
 	prometheusListen := flag.String("prometheus-listen-address", "", "give a valid ip:port address to expose Prometheus metrics at /metrics")
 	splitLogs := flag.Bool("split-logs", false, "split log output into stdout/stderr")
+	passthroughLogs := flag.Bool("passthrough-logs", false, "passthrough logs from commands, do not wrap them in Supercronic logging")
 	sentry := flag.String("sentry-dsn", "", "enable Sentry error logging, using provided DSN")
 	sentryAlias := flag.String("sentryDsn", "", "alias for sentry-dsn")
 	overlapping := flag.Bool("overlapping", false, "enable tasks overlapping")
@@ -131,7 +132,7 @@ func main() {
 				"job.position": job.Position,
 			})
 
-			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger, *overlapping, &promMetrics)
+			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger, *overlapping, *passthroughLogs, &promMetrics)
 		}
 
 		termChan := make(chan os.Signal, 1)


### PR DESCRIPTION
This adds support for not capturing logs at all, and instead just
passing them through. This has come up in a number of issues:
 #54, #55, #57, #65.