### PR TITLE
Update build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,13 @@ Note: If you are unsure which binary is right for you, try
 
 You can also build Supercronic from source.
 
-Supercronic uses `dep` for dependency management, so you'll need to [install
-dep][dep] first.
-
-Then, fetch Supercronic, install its dependencies, then install it:
+Run the following to fetch Supercronic, install its dependencies, and install
+it:
 
 ```
 go get -d github.com/aptible/supercronic
 cd "${GOPATH}/src/github.com/aptible/supercronic"
-dep ensure -vendor-only
+go mod vendor
 go install
 ```
 


### PR DESCRIPTION
The docs should be updated after 6a0e41f removed `Gopkg.toml`.