### PR TITLE
Add default Prometheus port

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,15 @@ func main() {
 	quiet := flag.Bool("quiet", false, "do not log informational messages (takes precedence over debug)")
 	json := flag.Bool("json", false, "enable JSON logging")
 	test := flag.Bool("test", false, "test crontab (does not run jobs)")
-	prometheusListen := flag.String("prometheus-listen-address", "", "give a valid ip:port address to expose Prometheus metrics at /metrics")
+	prometheusListen := flag.String(
+		"prometheus-listen-address",
+		"",
+		fmt.Sprintf(
+			"give a valid ip[:port] address to expose Prometheus metrics at /metrics (port defaults to %s), "+
+				"use 0.0.0.0 for all network interfaces.",
+			prometheus_metrics.DefaultPort,
+		),
+	)
 	splitLogs := flag.Bool("split-logs", false, "split log output into stdout/stderr")
 	passthroughLogs := flag.Bool("passthrough-logs", false, "passthrough logs from commands, do not wrap them in Supercronic logging")
 	sentry := flag.String("sentry-dsn", "", "enable Sentry error logging, using provided DSN")

--- a/prometheus_metrics/prommetrics_test.go
+++ b/prometheus_metrics/prommetrics_test.go
@@ -1,0 +1,45 @@
+package prometheus_metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAddr(t *testing.T) {
+	addr, err := getAddr("127.0.0.1:123")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "127.0.0.1:123", addr)
+	}
+
+	addr, err = getAddr("127.0.0.1")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "127.0.0.1:9746", addr)
+	}
+
+	addr, err = getAddr("[127.0.0.1]")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "[127.0.0.1]:9746", addr)
+	}
+
+	addr, err = getAddr("[::]:123")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "[::]:123", addr)
+	}
+
+	addr, err = getAddr("::")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "[::]:9746", addr)
+	}
+
+	addr, err = getAddr("0.0.0.0")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "0.0.0.0:9746", addr)
+	}
+
+	_, err = getAddr("")
+	assert.NotNil(t, err)
+
+	_, err = getAddr("[::]")
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
We have a port assigned, so might as well default to it.

Fixes: #74