### PR TITLE
Fix broken link to intro blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ See [LICENSE.md](./LICENSE.md).
 Copyright (c) 2019 [Aptible][aptible]. All rights reserved.
 
   [aptible-logo]: https://raw.github.com/aptible/straptible/master/lib/straptible/rails/templates/public.api/icon-60px.png
-  [blog-post]: https://www.aptible.com/blog/cron-for-containers-introduction-supercronic/
+  [blog-post]: https://www.aptible.com/blog/introducing-supercronic-cron-for-containers
   [cronexpr]: https://github.com/aptible/supercronic/tree/master/cronexpr
   [releases]: https://github.com/aptible/supercronic/releases
   [dep]: https://github.com/golang/dep


### PR DESCRIPTION
Looks like the title changed at some point. Thank you for this very useful tool!