### PR TITLE
healthcheck endpoint

### DIFF
--- a/prometheus_metrics/prommetrics.go
+++ b/prometheus_metrics/prommetrics.go
@@ -149,6 +149,10 @@ func InitHTTPServer(listenAddr string, shutdownContext context.Context) (func() 
              </html>`))
 	})
 
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`OK`))
+	})
+
 	shutdownClosure := func() error {
 		return promSrv.Shutdown(shutdownContext)
 	}


### PR DESCRIPTION
This PR adds a `/health` endpoint which does nothing more than returning plaintext `OK` response. It is useful for service discovery tools (consul/kubernetes etc.), to quickly say, that service is alive and running.