### PR TITLE
Add `-replacing` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ You can optionally disable this behavior and allow overlapping instances of
 your jobs by passing the `-overlapping` flag to Supercronic. Supercronic will
 still warn about jobs falling behind, but will run duplicate instances of them.
 
+If you pass `-replacing` flag and it's time for a new job iteration to run, 
+Supercronic will kill the previous job process if it hasn't finished yet.  
 
 ## Reload crontab
 

--- a/integration/test.bats
+++ b/integration/test.bats
@@ -62,6 +62,11 @@ wait_for() {
   [[ "$n" -ge 4 ]]
 }
 
+@test "it runs replacing jobs" {
+  n="$(SUPERCRONIC_ARGS="-replacing" run_supercronic "${BATS_TEST_DIRNAME}/timeout.crontab" 5s | grep -iE "killed" | wc -l)"
+  [[ "$n" -ge 3 ]]
+}
+
 @test "it supports debug logging " {
   SUPERCRONIC_ARGS="-debug" run_supercronic "${BATS_TEST_DIRNAME}/hello.crontab" | grep -iE "debug"
 }

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 	sentry := flag.String("sentry-dsn", "", "enable Sentry error logging, using provided DSN")
 	sentryAlias := flag.String("sentryDsn", "", "alias for sentry-dsn")
 	overlapping := flag.Bool("overlapping", false, "enable tasks overlapping")
+	replacing := flag.Bool("replacing", false, "enable tasks replacing")
 	flag.Parse()
 
 	var sentryDsn string
@@ -147,7 +148,7 @@ func main() {
 				"job.position": job.Position,
 			})
 
-			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger, *overlapping, *passthroughLogs, &promMetrics)
+			cron.StartJob(&wg, tab.Context, job, exitCtx, cronLogger, *overlapping, *replacing, *passthroughLogs, &promMetrics)
 		}
 
 		termChan := make(chan os.Signal, 1)


### PR DESCRIPTION
`-replacing` flag tells Supercronic to kill the previous job process if it hasn't finished yet, when it's time for a new job iteration to run.

With this flag Supersonic implements three available [concurrency policies][concurrency-policy] for Kubernetes [CronJob][cron-jobs]:

 - `Allow` - `-overlapping` flag.
 - `Forbid` - no flag, default behavior of Supercronic.
 - `Replace` - `-replacing` flag. 

It allows using Supercronic for running crons inside containers when it is too expensive to use CronJob to create pods on every run (e.g. running every minute).

  [concurrency-policy]: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy
  [cron-jobs]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/           