### PR TITLE
Dockerfile added

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs: # Docs: <https://git.io/JvxXE>
           context: .
           file: Dockerfile
           push: false
-          tags: app:ci
+          tags: supercronic:ci
 
-      - run: docker save app:ci > ./docker-image.tar
+      - run: docker save supercronic:ci > ./docker-image.tar
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: tests
+
+on:
+  push:
+    branches: [master, main]
+    tags-ignore: ['**']
+    paths-ignore: ['**.md']
+  pull_request:
+    paths-ignore: ['**.md']
+
+jobs: # Docs: <https://git.io/JvxXE>
+  docker-image:
+    name: Build docker image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: docker/build-push-action@v2 # Action page: <https://github.com/docker/build-push-action>
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: app:ci
+
+      - run: docker save app:ci > ./docker-image.tar
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docker-image
+          path: ./docker-image.tar
+          retention-days: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.2
+
+# Image page: <https://hub.docker.com/_/golang>
+# Inportant note: Do not forget to update the version here on Go update
+FROM golang:1.14-alpine as builder
+
+WORKDIR /src
+
+COPY . .
+
+RUN apk add --no-cache make bash
+
+RUN CGO_ENABLED=0 make build
+
+WORKDIR /tmp/rootfs
+
+# prepare rootfs for runtime
+RUN set -x \
+    && mkdir -p \
+        ./etc \
+        ./bin \
+    && echo 'supercronic:x:10001:10001::/nonexistent:/sbin/nologin' > ./etc/passwd \
+    && echo 'supercronic:x:10001:' > ./etc/group \
+    && mv /src/supercronic ./bin/supercronic
+
+# use empty filesystem
+FROM scratch as runtime
+
+LABEL \
+    # Docs: <https://github.com/opencontainers/image-spec/blob/master/annotations.md>
+    org.opencontainers.image.title="supercronic" \
+    org.opencontainers.image.description="Cron for containers" \
+    org.opencontainers.image.url="https://github.com/aptible/supercronic" \
+    org.opencontainers.image.source="https://github.com/aptible/supercronic" \
+    org.opencontainers.image.vendor="aptible" \
+    org.opencontainers.image.licenses="MIT"
+
+# import from builder
+COPY --from=builder /tmp/rootfs /
+
+# use an unprivileged user
+USER supercronic:supercronic
+
+ENTRYPOINT ["/bin/supercronic"]


### PR DESCRIPTION
Related issue: #85

Suggested workflow for the images publishing on docker hub & GitHub containers (GitHub actions):

```yaml
name: release

on:
  release: # Docs: <https://git.io/JeBz1#release-event-release>
    types: [published]

jobs:
  docker-image:
    name: Build docker image
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v2

      - uses: gacts/github-slug@v1 # Action page: <https://github.com/gacts/github-slug>
        id: slug

      - uses: docker/setup-qemu-action@v1 # Action page: <https://github.com/docker/setup-qemu-action>

      - uses: docker/setup-buildx-action@v1 # Action page: <https://github.com/docker/setup-buildx-action>

      - uses: docker/login-action@v1 # Action page: <https://github.com/docker/login-action>
        with:
          username: aptible
          password: ${{ secrets.DOCKER_PASSWORD }}

      - uses: docker/login-action@v1 # Action page: <https://github.com/docker/login-action>
        with:
          registry: ghcr.io
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}

      - uses: docker/build-push-action@v2 # Action page: <https://github.com/docker/build-push-action>
        with:
          context: .
          file: Dockerfile
          push: true
          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
          tags: |
            aptible/supercronic:${{ steps.slug.outputs.version }}
            aptible/supercronic:latest
            ghcr.io/aptible/supercronic:${{ steps.slug.outputs.version }}
            ghcr.io/aptible/supercronic:latest
```