### PR TITLE
Configure pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: lint-crontab
+  name: Lint crontab files
+  description: Lint crontab files for scheduling syntax
+  language: golang
+  types: [file]
+  files: \.crontab$
+  entry: supercronic -test

--- a/main.go
+++ b/main.go
@@ -23,6 +23,24 @@ var Usage = func() {
 	flag.PrintDefaults()
 }
 
+func testCrontabFiles(fileNames []string) int {
+	exitCode := 0
+
+	for _, fileName := range fileNames {
+		logrus.Infof("read crontab: %s", fileName)
+		_, err := readCrontabAtPath(fileName)
+
+		if err != nil {
+			logrus.Error(err)
+			exitCode = 1
+		} else {
+			logrus.Infof("crontab is valid: %s", fileName)
+		}
+	}
+
+	return exitCode
+}
+
 func main() {
 	debug := flag.Bool("debug", false, "enable debug logging")
 	quiet := flag.Bool("quiet", false, "do not log informational messages (takes precedence over debug)")
@@ -77,9 +95,17 @@ func main() {
 		)
 	}
 
-	if flag.NArg() != 1 {
+	// Allow FILE... for test flag to use with linting
+	validArgs := flag.NArg() == 1 || (*test && flag.NArg() > 1)
+	if !validArgs {
 		Usage()
 		os.Exit(2)
+		return
+	}
+
+	if *test {
+		fileNames := flag.Args()
+		os.Exit(testCrontabFiles(fileNames))
 		return
 	}
 
@@ -128,12 +154,6 @@ func main() {
 
 		if err != nil {
 			logrus.Fatal(err)
-			break
-		}
-
-		if *test {
-			logrus.Info("crontab is valid")
-			os.Exit(0)
 			break
 		}
 


### PR DESCRIPTION
We use [pre-commit](https://pre-commit.com/) to run a series of linters/fixers against our code before we land diffs in the main branch. I've put together a simple integration for pre-commit for supercronic, and was wondering if this would be something that's useful to merge into upstream.

In order to define a linter, a `.pre-commit-hooks.yaml` file needs to be added to the root of the repo, and - depending on the language - an environment will be automatically set up to run the linter. In this case, golang runs `go install ./...`, so we can use the supercronic binary

Other than adding the hooks config file, the main change in this PR is to allow multiple filenames to be passed in combination with the `-test` flag. This is how pre-commit works: it sends the list of files to the entrypoint as args.

By default, I've configured the pre-commit hook to look changes to files with `.crontab`, but users can override this in their own repo configs.

Let me know if this is something you'd want to merge in. No worries if not -- happy to close this PR if it's not relevant, and we'll continue to use the fork.