### PR TITLE
Fix broken formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You can also override the timezone by setting the environment variable `TZ`
 (e.g. `TZ=Europe/Berlin`) when running Supercronic. You may need to install
 `tzdata` in order for Supercronic to find the supplied timezone.
 
-You can override `TZ  to use a different timezone, but if you need your cron
+You can override `TZ` to use a different timezone, but if you need your cron
 jobs to be scheduled in a timezone A and have them run in a timezone B, you can
 run with `/etc/localtime` or `TZ` set to `B` and add a `CRON_TZ=A` line to your
 crontab.


### PR DESCRIPTION
I noticed this problem while reading the README here on GitHub:
![image](https://user-images.githubusercontent.com/207748/216600656-c728a6c5-47bc-4625-8d13-77e82e426445.png)
