### PR TITLE
Bump to current Go verion.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aptible/supercronic
 
-go 1.18
+go 1.20
 
 require (
 	github.com/evalphobia/logrus_sentry v0.8.2


### PR DESCRIPTION
1.18 is EOL as of this past February.