### PR TITLE
Add support for -version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: build assets
-      run: make release
+      run: make release VERSION=${{ github.event.release.tag_name }}
 
     - name: gh login
       run:  echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 SHELL=/bin/bash
+VERSION=$(shell git describe --tags --always --dirty)
 
 .PHONY: deps
 deps:
@@ -7,7 +8,7 @@ deps:
 
 .PHONY: build
 build: $(GOFILES)
-	go build
+	go build -ldflags "-X main.Version=${VERSION}"
 
 .PHONY: unit
 unit:
@@ -15,6 +16,7 @@ unit:
 	go vet $$(go list ./... | grep -v /vendor/)
 
 .PHONY: integration
+integration: VERSION=v1337
 integration: build
 	bats integration
 
@@ -32,6 +34,6 @@ fmt:
 
 .PHONY: release
 release:
-	./build.sh
+	./build.sh ${VERSION}
 
 .DEFAULT_GOAL := test

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,8 @@ set -x
 mkdir -p dist
 export GOOS="linux"
 export CGO_ENABLED=0
-for arch in amd64 386 arm arm64; do GOARCH="$arch" go build && file supercronic | grep 'statically linked' && mv supercronic "dist/supercronic-${GOOS}-${arch}"; done
+VERSION=${1:-$(git describe --tags --always --dirty)}
+for arch in amd64 386 arm arm64; do GOARCH="$arch" go build -ldflags="-X 'main.Version=$VERSION'" && file supercronic | grep 'statically linked' && mv supercronic "dist/supercronic-${GOOS}-${arch}"; done
 pushd dist
 ls -lah *
 file *

--- a/integration/test.bats
+++ b/integration/test.bats
@@ -27,6 +27,11 @@ wait_for() {
   return 1
 }
 
+@test "it prints the version" {
+    run "${BATS_TEST_DIRNAME}/../supercronic" -version
+    [[ "$output" =~ ^v1337$ ]]
+}
+
 @test "it starts" {
   run_supercronic "${BATS_TEST_DIRNAME}/noop.crontab"
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	Version = "<unset>"
+)
+
 var Usage = func() {
 	fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS] CRONTAB\n\nAvailable options:\n", os.Args[0])
 	flag.PrintDefaults()
@@ -29,6 +33,7 @@ func main() {
 	debug := flag.Bool("debug", false, "enable debug logging")
 	quiet := flag.Bool("quiet", false, "do not log informational messages (takes precedence over debug)")
 	json := flag.Bool("json", false, "enable JSON logging")
+	printVersion := flag.Bool("version", false, "print version and exit")
 	test := flag.Bool("test", false, "test crontab (does not run jobs)")
 	inotify := flag.Bool("inotify", false, "use inotify to detect crontab file changes")
 	prometheusListen := flag.String(
@@ -94,6 +99,12 @@ func main() {
 			os.Stdout,
 			os.Stderr,
 		)
+	}
+
+	if *printVersion {
+		fmt.Println(Version)
+		os.Exit(0)
+		return
 	}
 
 	if flag.NArg() != 1 {


### PR DESCRIPTION
Having a `-version` flag allows users to programmatically determine the version the binary is built on. This is needed for automated build environments.