### PR TITLE
Make the integration test not dependent on version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ unit:
 	go vet $$(go list ./... | grep -v /vendor/)
 
 .PHONY: integration
-integration: VERSION=v1337
 integration: build
 	bats integration
 

--- a/integration/test.bats
+++ b/integration/test.bats
@@ -29,7 +29,7 @@ wait_for() {
 
 @test "it prints the version" {
     run "${BATS_TEST_DIRNAME}/../supercronic" -version
-    [[ "$output" =~ ^v1337$ ]]
+    [[ "$output" != "<unset> ]]
 }
 
 @test "it starts" {


### PR DESCRIPTION
I was building supercronic locally and ran the integration tests and noticed this little annoyance. I don't think the integration test should check the exact version it expects, just whether the version is unset or not.

I am open for discussion, though.

:shipit: 