### PR TITLE
feat: add nanoseconds in log timestamp

### DIFF
--- a/integration/test.bats
+++ b/integration/test.bats
@@ -79,6 +79,17 @@ wait_for() {
   SUPERCRONIC_ARGS="-passthrough-logs" run_supercronic "${BATS_TEST_DIRNAME}/hello.crontab" | grep -iE "^hello from crontab$"
 }
 
+@test "it supports nanosecond timestamp precision in logs" {
+  output=$(SUPERCRONIC_ARGS="-nano-timestamps" run_supercronic "${BATS_TEST_DIRNAME}/hello.crontab")
+  echo "$output" | grep -E "time=\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}[+-][0-9]{2}:[0-9]{2}\""
+}
+
+@test "it uses standard timestamp format by default" {
+  output=$(run_supercronic "${BATS_TEST_DIRNAME}/hello.crontab" 1s)
+  echo "$output" | grep -E "time=\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}\""
+  ! echo "$output" | grep -E "time=\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}[+-][0-9]{2}:[0-9]{2}\""
+}
+
 @test "it waits for jobs to exit before terminating" {
   ready="will start"
   canary="all done"

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 	sentryReleaseFlag := flag.String("sentry-release", "", "specify the application's release version for Sentry error reporting")
 	sentryAlias := flag.String("sentryDsn", "", "alias for sentry-dsn")
 	overlapping := flag.Bool("overlapping", false, "enable tasks overlapping")
+	nanoTimestamps := flag.Bool("nano-timestamps", false, "include nanoseconds in log timestamps")
 	flag.Parse()
 
 	var (
@@ -92,7 +93,11 @@ func main() {
 	if *json {
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 	} else {
-		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+		textFormatter := &logrus.TextFormatter{FullTimestamp: true}
+		if *nanoTimestamps {
+			textFormatter.TimestampFormat = time.RFC3339Nano
+		}
+		logrus.SetFormatter(textFormatter)
 	}
 	if *splitLogs {
 		hook.RegisterSplitLogger(
@@ -123,7 +128,7 @@ func main() {
 			forkExec()
 			return
 		}
-		
+
 		logrus.Warn("process reaping disabled, not pid 1")
 	}
 	crontabFileName := flag.Args()[0]


### PR DESCRIPTION
Introduce new cli flag `-nano-timestamps` to include nanoseconds in log timestamps