### PR TITLE
support linux/loong64 to release target

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ mkdir -p dist
 export GOOS="linux"
 export CGO_ENABLED=0
 VERSION=${1:-$(git describe --tags --always --dirty)}
-for arch in amd64 386 arm arm64; do GOARCH="$arch" go build -ldflags="-X 'main.Version=$VERSION'" && file supercronic | grep 'statically linked' && mv supercronic "dist/supercronic-${GOOS}-${arch}"; done
+for arch in amd64 386 arm arm64 loong64; do GOARCH="$arch" go build -ldflags="-X 'main.Version=$VERSION'" && file supercronic | grep 'statically linked' && mv supercronic "dist/supercronic-${GOOS}-${arch}"; done
 pushd dist
 ls -lah *
 file *


### PR DESCRIPTION
I completed the build and verification on linux/loong64, as shown below. Should we consider releasing a loong64 version as well?
<img width="1254" height="239" alt="image" src="https://github.com/user-attachments/assets/99b9cfc7-7f9d-4ec5-9e95-56dc9142c2e1" />
