### PR TITLE
bump go to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aptible/supercronic
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/evalphobia/logrus_sentry v0.8.2


### PR DESCRIPTION
## Bump Go Version to 1.25.5

Addresses [CVE-2025-61729](https://nvd.nist.gov/vuln/detail/CVE-2025-61729)

- Description: In HostnameError.Error() in crypto/tls, constructing error strings has no limit on the number of hosts printed and uses repeated string concatenation, causing quadratic runtime. A malicious certificate can cause excessive resource consumption (DoS).
- Severity: HIGH (CVSS 7.5)
- Attack vector: NETWORK
- Affected package: crypto/tls (Go standard library)
- References: https://go.dev/issue/76445, https://pkg.go.dev/vuln/GO-2025-4155

### Detailed Analysis
Vulnerable Go Version: The go.mod file specifies go 1.25.3.
Status: This version is AFFECTED. The vulnerability exists in Go versions 1.25.0 through 1.25.4 (fixed in 1.25.5) and versions before 1.24.11.

### Usage of crypto/tls:
Direct Usage: The codebase does not directly import crypto/tls.
Indirect Usage (Client-Side): The application integrates with Sentry via github.com/evalphobia/logrus_sentry. This library (and its underlying dependencies) uses Go's net/http to send error reports to Sentry. When a SENTRY_DSN is configured (typically https://...), the standard library's crypto/tls package is used to handle the encrypted connection.
Server-Side: The Prometheus metrics server (prometheus_metrics/prommetrics.go) uses net/http but listens on a plain TCP socket (net.Listen("tcp", addr)) without TLS configuration. It is not vulnerable as a server.

### Attack Vector & Risk:
Mechanism: The vulnerability lies in HostnameError.Error(), which causes excessive CPU consumption (DoS) when constructing an error message for a certificate that fails hostname verification.
Scenario: For Supercronic to be exploited, it must:
Be configured with Sentry enabled (-sentry-dsn).
Attempt to connect to the Sentry server.
Be intercepted by an attacker (MITM) or misdirected (DNS spoofing) to a malicious server presenting a specially crafted certificate that triggers a hostname mismatch error.

**Likelihood: Low**. Since Supercronic is typically a backend process in a containerized environment, an attacker would need significant control over the network infrastructure to intercept the Sentry traffic. It does not expose a TLS service to the public internet.