### PR TITLE
Add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ go mod vendor
 go install
 ```
 
+To cross-compile for Windows:
+
+```
+GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o supercronic.exe .
+```
+
 
 ## Crontab format ##
 
@@ -249,6 +255,17 @@ time="2024-09-11T09:23:18+02:00" level=debug msg="try parse (5 fields): '* * * *
 time="2024-09-11T09:23:18+02:00" level=debug msg="job will run next at 2024-09-11 09:24:00 +0200 CEST" job.command="sleep 5" job.position=0 job.schedule="* * * * *"
 
 ```
+
+## Windows
+
+Supercronic runs on Windows. A few platform differences to be aware of:
+
+- The default shell is `cmd.exe` with the `/C` flag. Set `SHELL=powershell.exe`
+  in your crontab to use PowerShell instead.
+- `SIGUSR2`-based crontab reloads are not supported on Windows. Use the
+  `-inotify` flag instead -- supercronic uses `ReadDirectoryChangesW` under
+  the hood, so file-watch-based reloads work correctly on Windows.
+- Process reaping (PID 1 mode) is not applicable on Windows.
 
 ## Testing your crontab
 

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"bufio"
+	"runtime"
 	"context"
 	"fmt"
 	"io"
@@ -9,7 +10,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/aptible/supercronic/crontab"
@@ -66,11 +66,15 @@ func startReaderDrain(wg *sync.WaitGroup, readerLogger *logrus.Entry, reader io.
 func runJob(cronCtx *crontab.Context, command string, jobLogger *logrus.Entry, passthroughLogs bool) error {
 	jobLogger.Info("starting")
 
-	cmd := exec.Command(cronCtx.Shell, "-c", command)
+	args := []string{"-c", command}
+	if runtime.GOOS == "windows" {
+		args[0] = "-Command"
+	}
+	cmd := exec.Command(cronCtx.Shell, args...)
 
 	// Run in a separate process group so that in interactive usage, CTRL+C
 	// stops supercronic, not the children threads.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = sysProcAttr()
 
 	env := os.Environ()
 	for k, v := range cronCtx.Environ {

--- a/cron/unix.go
+++ b/cron/unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package cron
+
+import "syscall"
+
+// sysProcAttr returns a SysProcAttr that runs the child in its own process
+// group so that CTRL+C in interactive usage stops supercronic, not the child.
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/cron/windows.go
+++ b/cron/windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package cron
+
+import "syscall"
+
+// sysProcAttr returns an empty SysProcAttr; Setpgid is not supported on Windows.
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}

--- a/crontab/crontab.go
+++ b/crontab/crontab.go
@@ -2,6 +2,7 @@ package crontab
 
 import (
 	"bufio"
+	"runtime"
 	"fmt"
 	"io"
 	"regexp"
@@ -66,6 +67,9 @@ func ParseCrontab(reader io.Reader) (*Crontab, error) {
 
 	environ := make(map[string]string)
 	shell := "/bin/sh"
+	if runtime.GOOS == "windows" {
+		shell = "powershell.exe"
+	}
 	tz := time.Local
 
 	for scanner.Scan() {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/aptible/supercronic/cron"
@@ -205,7 +204,7 @@ func main() {
 					switch event.Op {
 					case event.Op & fsnotify.Write:
 						logrus.Debug("watched file changed")
-						termChan <- syscall.SIGUSR2
+						termChan <- reloadSignal
 
 					// workaround for k8s configmap and secret mounts
 					case event.Op & fsnotify.Remove:
@@ -214,7 +213,7 @@ func main() {
 							logrus.Fatal(err)
 							return
 						}
-						termChan <- syscall.SIGUSR2
+						termChan <- reloadSignal
 					}
 
 				case err, ok := <-watcher.Errors:
@@ -259,7 +258,7 @@ func main() {
 
 		termSig := <-termChan
 
-		if termSig == syscall.SIGUSR2 {
+		if termSig == reloadSignal {
 			logrus.Infof("received %s, reloading crontab", termSig)
 		} else {
 			logrus.Infof("received %s, shutting down", termSig)
@@ -269,7 +268,7 @@ func main() {
 		logrus.Info("waiting for jobs to finish")
 		wg.Wait()
 
-		if termSig != syscall.SIGUSR2 {
+		if termSig != reloadSignal {
 			logrus.Info("exiting")
 			break
 		}
@@ -287,6 +286,4 @@ func readCrontabAtPath(path string) (*crontab.Crontab, error) {
 	return crontab.ParseCrontab(file)
 }
 
-var signalList = []os.Signal{
-	syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGUSR2,
-}
+

--- a/reaper.go
+++ b/reaper.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package main
 
 import (
@@ -7,6 +9,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 )
+
+// reloadSignal is the signal used to trigger a live crontab reload.
+var reloadSignal os.Signal = syscall.SIGUSR2
+
+var signalList = []os.Signal{
+	syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGUSR2,
+}
 
 func forkExec() {
 

--- a/windows.go
+++ b/windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+// forkExec is a no-op on Windows; process reaping is a Linux-only concept
+// and supercronic will never run as PID 1 on Windows.
+func forkExec() {
+	logrus.Fatal("process reaping is not supported on Windows")
+}
+
+// reloadSig is a synthetic sentinel used to trigger crontab reloads on
+// platforms that do not support SIGUSR2 (e.g. via fsnotify file watch).
+type reloadSig struct{}
+
+func (reloadSig) String() string { return "reload" }
+func (reloadSig) Signal()        {}
+
+// reloadSignal is the signal used to trigger a live crontab reload.
+var reloadSignal os.Signal = reloadSig{}
+
+// signalList contains the OS signals supercronic listens for on Windows.
+// reloadSignal is intentionally excluded as it is a synthetic sentinel that
+// cannot be delivered by the OS; reloads are triggered via fsnotify instead.
+var signalList = []os.Signal{
+	syscall.SIGINT, syscall.SIGTERM,
+}


### PR DESCRIPTION

## Add Windows support

Closes #102

Adds cross-compilation and runtime support for Windows. Tested running as a Windows service with a real crontab firing on schedule.

### Approach

Build tags are used only where a symbol literally doesn't exist on Windows and would cause a compile error regardless of code path (`Setpgid`, `SIGUSR2`, `ForkExec`, `Wait4`, `SIGCHLD`). Everything else uses `runtime.GOOS` to keep the number of new files minimal.

Three new files:

- `cron/unix.go` / `cron/windows.go` — platform split for `sysProcAttr()` since `Setpgid` won't compile on Windows even in dead code
- `windows.go` — all main package Windows stubs in one place: `forkExec` no-op, synthetic `reloadSig` sentinel, and a Windows-appropriate `signalList`

Four modified files:

- `reaper.go` — `//go:build !windows` tag; `reloadSignal` and `signalList` moved here for the Unix side
- `cron/cron.go` — `sysProcAttr()` call; `runtime.GOOS` to select `-c` vs `-Command` shell flag
- `crontab/crontab.go` — `runtime.GOOS` to default to `powershell.exe` on Windows instead of `/bin/sh`
- `main.go` — `syscall.SIGUSR2` replaced with `reloadSignal` throughout; `syscall` import removed

### Platform notes

**Default shell**: `powershell.exe` with `-Command`. Override with `SHELL=` in your crontab as usual.

**Crontab reload**: `SIGUSR2` can't be delivered to a Windows process externally so that path is a no-op on Windows. The `-inotify` flag works correctly via `ReadDirectoryChangesW` and is the recommended reload mechanism on Windows.

**Process reaping**: `forkExec()` is stubbed with `logrus.Fatal`. The reaper is only entered when `os.Getpid() == 1`, which is never true on Windows, so it's dead code in practice.
