### PR TITLE
fix(crontab): avoid panic on env line with empty value

### DIFF
--- a/crontab/crontab.go
+++ b/crontab/crontab.go
@@ -85,7 +85,7 @@ func ParseCrontab(reader io.Reader) (*Crontab, error) {
 			envVal := r[0][2]
 
 			// Remove quotes (this emulates what Vixie cron does)
-			if envVal[0] == '"' || envVal[0] == '\'' {
+			if len(envVal) > 0 && (envVal[0] == '"' || envVal[0] == '\'') {
 				if len(envVal) > 1 && envVal[0] == envVal[len(envVal)-1] {
 					envVal = envVal[1 : len(envVal)-1]
 				}

--- a/crontab/crontab_test.go
+++ b/crontab/crontab_test.go
@@ -111,6 +111,18 @@ var parseCrontabTestCases = []struct {
 	},
 
 	{
+		"FOO=",
+		&Crontab{
+			Context: &Context{
+				Shell:    "/bin/sh",
+				Environ:  map[string]string{"FOO": ""},
+				Timezone: time.Local,
+			},
+			Jobs: []*Job{},
+		},
+	},
+
+	{
 		"CRON_TZ=UTC",
 		&Crontab{
 			Context: &Context{


### PR DESCRIPTION
## What's broken

`ParseCrontab` panics on a crontab that contains an environment line with an empty value, e.g. `FOO=` — a valid Vixie-cron construct (clearing/setting a variable to empty). Instead of parsing it, supercronic crashes at startup:

```
panic: runtime error: index out of range [0] with length 0
  github.com/aptible/supercronic/crontab.ParseCrontab
      crontab/crontab.go:88
```

## Why it happens

The env regex `^([^\s=]+)\s*=\s*(.*)$` lets the value group match the empty string, so `envVal == ""`. The quote-stripping block then indexes `envVal[0]` unconditionally. The existing `FOO=''` test doesn't hit this because there `envVal` is `"''"` (length 2) at that point; only a bare `FOO=` produces a zero-length value.

## Fix

Guard the quote check with `len(envVal) > 0`. Empty values parse to an empty string, consistent with the existing `FOO=''` behaviour.

## Test

Added a `FOO=` case to `TestParseCrontab` asserting it parses to `{"FOO": ""}`; panics before, passes after.
