### PR TITLE
Build minimal container image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,125 @@
+name: container
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  GO_VERSION: '1.26.4'
+
+jobs:
+  build:
+    # Avoid running on tag pushes for forks; secrets aren't available.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: log in to ghcr
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: derive metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYYMMDD'}}-{{sha}},enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=supercronic
+            org.opencontainers.image.description=Crontab-compatible job runner for containers
+            org.opencontainers.image.source=https://github.com/aptible/supercronic
+
+      - name: build and push (Go ${{ env.GO_VERSION }})
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            GO_VERSION=${{ env.GO_VERSION }}
+
+      - name: sanity check
+        if: github.event_name == 'pull_request'
+        run: |
+          set -e
+          docker run --rm ${{ steps.build.outputs.imageid }} -version
+
+  sign:
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        with:
+          cosign-release: 'v2.2.3'
+
+      - name: derive metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: sign images
+        env:
+          COSIGN_EXPERIMENTAL: '1'
+        run: |
+          set -e
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            cosign sign --yes "$tag"
+            cosign verify --certificate-identity-regexp 'https://github.com/' \
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+              "$tag"
+          done

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.4
 FROM docker.io/library/golang:${GO_VERSION}-alpine AS build
 
 ARG VERSION=dev

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,35 @@
+# Build stage
+ARG GO_VERSION=1.26.5
+FROM docker.io/library/golang:${GO_VERSION}-alpine AS build
+
+ARG VERSION=dev
+
+WORKDIR /src
+
+# Cache dependencies first.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Build the static binary.
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build -trimpath -ldflags "-s -w -X main.Version=${VERSION}" \
+    -o /out/supercronic ./
+
+# Final stage
+FROM scratch
+
+# OCI labels.
+LABEL org.opencontainers.image.title="supercronic" \
+      org.opencontainers.image.description="Crontab-compatible job runner for containers" \
+      org.opencontainers.image.source="https://github.com/aptible/supercronic"
+
+
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group  /etc/group
+
+COPY --from=build /out/supercronic /usr/local/bin/supercronic
+
+USER nobody:nobody
+
+ENTRYPOINT ["/usr/local/bin/supercronic"]


### PR DESCRIPTION
# Context

More and more platform allow to create volume tied to a Container image:
- [Kubernetes VolumeImage](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
- [Podman Volume image driver](https://docs.podman.io/en/latest/markdown/podman-volume-create.1.html)

It offers a way to provide `supercronic` without touching the Container image that will contain the program to be scheduled:
- 1. Create volume image that use `supercronic` container image as reference
- 2. Create volume with `crontab` _configuration_
- 3. Change entrypoint to `supercronic` 

# Description

This PR provide:
- a Containerfile to build a minimal `supercronic` container image (multi-stage build with final layer based on _scratch_)
- Github workflow to build container image on PR merge or tagging